### PR TITLE
Blank lines in vfstab cause exception

### DIFF
--- a/svr4mount
+++ b/svr4mount
@@ -31,7 +31,7 @@ class Mount(object):
         exists = False
         for line in self.vfstab:
             field = line.split()
-            if field[0].count('#') > 0:
+            if len(field) == 0 or field[0].count('#') > 0:
                 continue
             if self.name == field[2]:
                 exists = True
@@ -41,7 +41,7 @@ class Mount(object):
         changed = False
         for i in range(0, len(self.vfstab)):
             field = self.vfstab[i].split()
-            if field[0].count('#') > 0:
+            if len(field) == 0 or field[0].count('#') > 0:
                 continue
             if self.name == field[2]:
                 if self.src != field[0] or \


### PR DESCRIPTION
A blank line in `/etc/vfstab` will cause:

```
invalid output was: Traceback (most recent call last):
  File "/tmp/ansible-tmp-1402370316.9-115108565709265/svr4mount", line 1392, in <module>
    main()
  File "/tmp/ansible-tmp-1402370316.9-115108565709265/svr4mount", line 152, in main
    if mount.entry_exists():
  File "/tmp/ansible-tmp-1402370316.9-115108565709265/svr4mount", line 34, in entry_exists
    if field[0].count('#') > 0:
IndexError: list index out of range
```

I was actually managing a fresh install of Solaris 11.1, and there was a blank line at the end of the file.

This PR avoids the exception by skipping blank lines.
